### PR TITLE
[rpc_parallel] fix jbuild

### DIFF
--- a/core/src/jbuild
+++ b/core/src/jbuild
@@ -1,6 +1,5 @@
 (library
  ((name rpc_parallel_core_deprecated)
-  (public_name rpc_parallel.core)
   (libraries (core
               async
               sexplib))

--- a/src/jbuild
+++ b/src/jbuild
@@ -1,5 +1,6 @@
 (library
  ((name rpc_parallel)
+  (public_name rpc_parallel)
   (libraries (core
               async
               sexplib))


### PR DESCRIPTION
Currently this is only exporting the deprecated core module.

Tested: `make` actually builds what's in the `src/` subdirectory.