### PR TITLE
Support for macOS

### DIFF
--- a/src/jbuild
+++ b/src/jbuild
@@ -5,6 +5,7 @@
               core
               core.daemon
               sexplib
+              ctypes
               core.uuid))
   (preprocess (pps (ppx_jane ppxlib.runner)))))
 

--- a/src/parallel.ml
+++ b/src/parallel.ml
@@ -769,8 +769,9 @@ module Make (S : Worker_spec) = struct
     >>=? fun env ->
     match where with
     | Executable_location.Local ->
+      Utils.our_binary () >>=? fun our_binary ->
       Process.create
-        ~prog:(Utils.our_binary ())
+        ~prog:our_binary
         ~argv0:Sys.argv.(0)
         ~args:worker_command_args
         ~env:(`Extend env)

--- a/src/remote_executable.ml
+++ b/src/remote_executable.ml
@@ -30,9 +30,10 @@ let copy_to_host ~executable_dir ?strict_host_key_checking host =
   >>=? fun new_basename ->
   let options = hostkey_checking_options strict_host_key_checking in
   let path = String.strip (executable_dir ^/ new_basename) in
+  Utils.our_binary () >>=? fun our_binary ->
   Process.run
     ~prog:"scp"
-    ~args:(options @ [ Utils.our_binary (); sprintf "%s:%s" host path ])
+    ~args:(options @ [ our_binary; sprintf "%s:%s" host path ])
     ()
   >>|? Fn.const { host; path; host_key_checking = options }
 ;;

--- a/src/utils.mli
+++ b/src/utils.mli
@@ -49,7 +49,7 @@ val try_within_exn : monitor:Monitor.t -> (unit -> 'a Deferred.t) -> 'a Deferred
 
 (* Get the location of the currently running binary. *)
 
-val our_binary : unit -> string
+val our_binary : unit -> string Or_error.t Deferre.t
 
 (* Get an md5 hash of the currently running binary *)
 

--- a/src/utils.mli
+++ b/src/utils.mli
@@ -49,7 +49,7 @@ val try_within_exn : monitor:Monitor.t -> (unit -> 'a Deferred.t) -> 'a Deferred
 
 (* Get the location of the currently running binary. *)
 
-val our_binary : unit -> string Or_error.t Deferre.t
+val our_binary : unit -> string Or_error.t Deferred.t
 
 (* Get an md5 hash of the currently running binary *)
 


### PR DESCRIPTION
macOS doesn't have a procfs. The canonical way to get the full
executable path is to use the C-function _NSGetExecutablePath. I'm
branching on OS using `uname -s` and using _NSGetExecutablePath on
Darwin systems and keeping the default proc-lookup on other ones.

Note: I tested this against the v0.11.0 branch and it works, but I don't have the necessary infrastructure for building on master. There could be small compile errors here, I'm hoping someone with the correct environment can make those small fixes.

Signed-off-by: Brandon Kase <bkase@o1labs.org>